### PR TITLE
bug fixes

### DIFF
--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -6,6 +6,7 @@ use App\Models\Attendance;
 use App\Models\Category;
 use App\Models\Club;
 use App\Models\DashboardLayout;
+use App\Models\Group;
 use App\Models\Payment;
 use App\Models\Student;
 use App\Models\User;
@@ -36,28 +37,34 @@ class StatisticsController extends Controller
         $endDate = $request->input('end_date');
         $clubId = $request->input('club_id');
         $categoryId = $request->input('category_id');
+        $groupId = $request->input('group_id');
 
         // Calculate date range
         $dateRange = $this->calculateDateRange($range, $startDate, $endDate);
 
         // Gather all statistics
-        $statistics = $this->gatherStatistics($dateRange, $clubId, $categoryId);
+        $statistics = $this->gatherStatistics($dateRange, $clubId, $categoryId, $groupId);
 
         // Get clubs for filter
         $clubs = Club::select('id', 'name')->get();
         $categories = Category::select('id', 'name', 'gender')->get();
+
+        // Get groups based on selected club/category
+        $groups = $this->getFilteredGroups($clubId, $categoryId);
 
         return Inertia::render('Dashboard/Statistics/Index', [
             'layout' => $layout->widgets,
             'statistics' => $statistics,
             'clubs' => $clubs,
             'categories' => $categories,
+            'groups' => $groups,
             'filters' => [
                 'range' => $range,
                 'start_date' => $startDate,
                 'end_date' => $endDate,
                 'club_id' => $clubId,
                 'category_id' => $categoryId,
+                'group_id' => $groupId,
             ],
         ]);
     }
@@ -72,11 +79,17 @@ class StatisticsController extends Controller
         $endDate = $request->input('end_date');
         $clubId = $request->input('club_id');
         $categoryId = $request->input('category_id');
+        $groupId = $request->input('group_id');
 
         $dateRange = $this->calculateDateRange($range, $startDate, $endDate);
-        $statistics = $this->gatherStatistics($dateRange, $clubId, $categoryId);
+        $statistics = $this->gatherStatistics($dateRange, $clubId, $categoryId, $groupId);
 
-        return response()->json($statistics);
+        $groups = $this->getFilteredGroups($clubId, $categoryId);
+
+        return response()->json([
+            'statistics' => $statistics,
+            'groups' => $groups,
+        ]);
     }
 
     /**
@@ -157,21 +170,40 @@ class StatisticsController extends Controller
     /**
      * Gather all statistics.
      */
-    private function gatherStatistics(array $dateRange, ?int $clubId, ?int $categoryId = null): array
+    private function gatherStatistics(array $dateRange, ?int $clubId, ?int $categoryId = null, ?int $groupId = null): array
     {
         return [
-            'financial' => $this->getFinancialStats($dateRange, $clubId, $categoryId),
-            'attendance' => $this->getAttendanceStats($dateRange, $clubId, $categoryId),
-            'students' => $this->getStudentStats($dateRange, $clubId, $categoryId),
+            'financial' => $this->getFinancialStats($dateRange, $clubId, $categoryId, $groupId),
+            'attendance' => $this->getAttendanceStats($dateRange, $clubId, $categoryId, $groupId),
+            'students' => $this->getStudentStats($dateRange, $clubId, $categoryId, $groupId),
             'personnel' => $this->getPersonnelStats($clubId),
-            'progress' => $this->getProgressStats($dateRange, $clubId, $categoryId),
+            'progress' => $this->getProgressStats($dateRange, $clubId, $categoryId, $groupId),
         ];
+    }
+
+    /**
+     * Get groups filtered by club and/or category.
+     */
+    private function getFilteredGroups(?int $clubId, ?int $categoryId): array
+    {
+        if (! $clubId && ! $categoryId) {
+            return [];
+        }
+
+        return Group::query()
+            ->when($clubId, fn ($q) => $q->where('club_id', $clubId))
+            ->when($categoryId, fn ($q) => $q->where('category_id', $categoryId))
+            ->where('is_active', true)
+            ->select('id', 'name')
+            ->orderBy('order')
+            ->get()
+            ->toArray();
     }
 
     /**
      * Get financial statistics.
      */
-    private function getFinancialStats(array $dateRange, ?int $clubId, ?int $categoryId = null): array
+    private function getFinancialStats(array $dateRange, ?int $clubId, ?int $categoryId = null, ?int $groupId = null): array
     {
         $query = Payment::query();
 
@@ -188,6 +220,12 @@ class StatisticsController extends Controller
         if ($categoryId) {
             $query->whereHas('student', function ($q) use ($categoryId) {
                 $q->where('category_id', $categoryId);
+            });
+        }
+
+        if ($groupId) {
+            $query->whereHas('student', function ($q) use ($groupId) {
+                $q->where('group_id', $groupId);
             });
         }
 
@@ -222,6 +260,9 @@ class StatisticsController extends Controller
             ->when($categoryId, function ($q) use ($categoryId) {
                 $q->where('students.category_id', $categoryId);
             })
+            ->when($groupId, function ($q) use ($groupId) {
+                $q->where('students.group_id', $groupId);
+            })
             ->select('clubs.name as club_name', 'clubs.id as club_id', DB::raw('SUM(payments.value) as total'))
             ->groupBy('clubs.id', 'clubs.name')
             ->get();
@@ -236,6 +277,9 @@ class StatisticsController extends Controller
                 })
                 ->when($categoryId, function ($q) use ($categoryId) {
                     $q->whereHas('student', fn ($sq) => $sq->where('category_id', $categoryId));
+                })
+                ->when($groupId, function ($q) use ($groupId) {
+                    $q->whereHas('student', fn ($sq) => $sq->where('group_id', $groupId));
                 })
                 ->where('created_at', '>=', Carbon::now()->subMonths(12))
                 ->select(
@@ -262,6 +306,9 @@ class StatisticsController extends Controller
                 })
                 ->when($categoryId, function ($q) use ($categoryId) {
                     $q->whereHas('student', fn ($sq) => $sq->where('category_id', $categoryId));
+                })
+                ->when($groupId, function ($q) use ($groupId) {
+                    $q->whereHas('student', fn ($sq) => $sq->where('group_id', $groupId));
                 })
                 ->where('created_at', '>=', Carbon::now()->subMonths(12))
                 ->select(
@@ -300,7 +347,7 @@ class StatisticsController extends Controller
     /**
      * Get attendance statistics.
      */
-    private function getAttendanceStats(array $dateRange, ?int $clubId, ?int $categoryId = null): array
+    private function getAttendanceStats(array $dateRange, ?int $clubId, ?int $categoryId = null, ?int $groupId = null): array
     {
         $query = Attendance::query();
 
@@ -317,6 +364,12 @@ class StatisticsController extends Controller
         if ($categoryId) {
             $query->whereHas('student', function ($q) use ($categoryId) {
                 $q->where('category_id', $categoryId);
+            });
+        }
+
+        if ($groupId) {
+            $query->whereHas('student', function ($q) use ($groupId) {
+                $q->where('group_id', $groupId);
             });
         }
 
@@ -347,6 +400,9 @@ class StatisticsController extends Controller
             })
             ->when($categoryId, function ($q) use ($categoryId) {
                 $q->where('students.category_id', $categoryId);
+            })
+            ->when($groupId, function ($q) use ($groupId) {
+                $q->where('students.group_id', $groupId);
             })
             ->select(
                 'clubs.name as club_name',
@@ -379,6 +435,9 @@ class StatisticsController extends Controller
             ->when($categoryId, function ($q) use ($categoryId) {
                 $q->where('students.category_id', $categoryId);
             })
+            ->when($groupId, function ($q) use ($groupId) {
+                $q->where('students.group_id', $groupId);
+            })
             ->select(
                 'categories.name as category_name',
                 'categories.id as category_id',
@@ -409,6 +468,9 @@ class StatisticsController extends Controller
             })
             ->when($categoryId, function ($q) use ($categoryId) {
                 $q->where('students.category_id', $categoryId);
+            })
+            ->when($groupId, function ($q) use ($groupId) {
+                $q->where('students.group_id', $groupId);
             })
             ->where('attendances.status', 'absent')
             ->select(
@@ -445,7 +507,7 @@ class StatisticsController extends Controller
     /**
      * Get student statistics.
      */
-    private function getStudentStats(array $dateRange, ?int $clubId, ?int $categoryId = null): array
+    private function getStudentStats(array $dateRange, ?int $clubId, ?int $categoryId = null, ?int $groupId = null): array
     {
         $query = Student::query();
 
@@ -455,6 +517,10 @@ class StatisticsController extends Controller
 
         if ($categoryId) {
             $query->where('category_id', $categoryId);
+        }
+
+        if ($groupId) {
+            $query->where('group_id', $groupId);
         }
 
         // Total counts
@@ -483,6 +549,9 @@ class StatisticsController extends Controller
             ->when($categoryId, function ($q) use ($categoryId) {
                 $q->where('students.category_id', $categoryId);
             })
+            ->when($groupId, function ($q) use ($groupId) {
+                $q->where('students.group_id', $groupId);
+            })
             ->select('clubs.name as club_name', 'clubs.id as club_id', DB::raw('COUNT(*) as count'))
             ->groupBy('clubs.id', 'clubs.name')
             ->get();
@@ -495,6 +564,9 @@ class StatisticsController extends Controller
             })
             ->when($categoryId, function ($q) use ($categoryId) {
                 $q->where('students.category_id', $categoryId);
+            })
+            ->when($groupId, function ($q) use ($groupId) {
+                $q->where('students.group_id', $groupId);
             })
             ->select('categories.name as category_name', 'categories.id as category_id', 'categories.gender as category_gender', DB::raw('COUNT(*) as count'))
             ->groupBy('categories.id', 'categories.name', 'categories.gender')
@@ -516,6 +588,9 @@ class StatisticsController extends Controller
             })
             ->when($categoryId, function ($q) use ($categoryId) {
                 $q->where('students.category_id', $categoryId);
+            })
+            ->when($groupId, function ($q) use ($groupId) {
+                $q->where('students.group_id', $groupId);
             })
             ->select(
                 'clubs.name as club_name',
@@ -556,6 +631,9 @@ class StatisticsController extends Controller
             if ($categoryId) {
                 $newQuery->where('category_id', $categoryId);
             }
+            if ($groupId) {
+                $newQuery->where('group_id', $groupId);
+            }
             $newRegistrations = $newQuery
                 ->whereBetween('created_at', [$dateRange['start'], $dateRange['end']])
                 ->count();
@@ -569,6 +647,9 @@ class StatisticsController extends Controller
         }
         if ($categoryId) {
             $negativeCreditQuery->where('category_id', $categoryId);
+        }
+        if ($groupId) {
+            $negativeCreditQuery->where('group_id', $groupId);
         }
         $negativeCredit = $negativeCreditQuery
             ->select('id', 'first_name', 'last_name', 'sessions_credit')
@@ -587,12 +668,14 @@ class StatisticsController extends Controller
             ->where('sessions_credit', '<', 0)
             ->when($clubId, fn ($q) => $q->where('club_id', $clubId))
             ->when($categoryId, fn ($q) => $q->where('category_id', $categoryId))
+            ->when($groupId, fn ($q) => $q->where('group_id', $groupId))
             ->count();
 
         // Expiring insurance (next 30 days)
         $expiringInsurance = Student::query()
             ->when($clubId, fn ($q) => $q->where('club_id', $clubId))
             ->when($categoryId, fn ($q) => $q->where('category_id', $categoryId))
+            ->when($groupId, fn ($q) => $q->where('group_id', $groupId))
             ->whereNotNull('insurance_expire_at')
             ->whereBetween('insurance_expire_at', [Carbon::now(), Carbon::now()->addDays(30)])
             ->select('id', 'first_name', 'last_name', 'insurance_expire_at')
@@ -610,6 +693,7 @@ class StatisticsController extends Controller
         $expiringInsuranceCount = Student::query()
             ->when($clubId, fn ($q) => $q->where('club_id', $clubId))
             ->when($categoryId, fn ($q) => $q->where('category_id', $categoryId))
+            ->when($groupId, fn ($q) => $q->where('group_id', $groupId))
             ->whereNotNull('insurance_expire_at')
             ->whereBetween('insurance_expire_at', [Carbon::now(), Carbon::now()->addDays(30)])
             ->count();
@@ -756,7 +840,7 @@ class StatisticsController extends Controller
     /**
      * Get progress statistics.
      */
-    private function getProgressStats(array $dateRange, ?int $clubId, ?int $categoryId = null): array
+    private function getProgressStats(array $dateRange, ?int $clubId, ?int $categoryId = null, ?int $groupId = null): array
     {
         $query = Student::query();
 
@@ -766,6 +850,10 @@ class StatisticsController extends Controller
 
         if ($categoryId) {
             $query->where('category_id', $categoryId);
+        }
+
+        if ($groupId) {
+            $query->where('group_id', $groupId);
         }
 
         // Calculate average memorization progress

--- a/app/Http/Controllers/StudentResourceController.php
+++ b/app/Http/Controllers/StudentResourceController.php
@@ -70,7 +70,8 @@ class StudentResourceController extends Controller
             'lastHizbAttendance.hizb',
             'lastThomanAttendance.thoman',
         ]);
-        $students = $query->paginate(10, ['id', 'first_name', 'last_name', 'birthdate', 'ahzab', 'ahzab_up', 'ahzab_down', 'gender', 'insurance_expire_at', 'subscription', 'subscription_expire_at', 'sessions_credit', 'club_id', 'category_id'])->withQueryString();
+        $perPage = in_array((int) $request->input('per_page'), [10, 25, 50, 100]) ? (int) $request->input('per_page') : 10;
+        $students = $query->paginate($perPage, ['id', 'first_name', 'last_name', 'birthdate', 'ahzab', 'ahzab_up', 'ahzab_down', 'gender', 'insurance_expire_at', 'subscription', 'subscription_expire_at', 'sessions_credit', 'club_id', 'category_id'])->withQueryString();
 
         $students->getCollection()->transform(function ($student) {
             $student->name = $student->first_name.' '.$student->last_name;
@@ -562,7 +563,7 @@ class StudentResourceController extends Controller
 
         $student->delete();
 
-        return redirect()->route('students.index')->with('success', 'تم حذف الطالب بنجاح');
+        return redirect()->back()->with('success', 'تم حذف الطالب بنجاح');
     }
 
     /**

--- a/resources/js/Components/ui/skeleton.tsx
+++ b/resources/js/Components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/resources/js/Pages/Dashboard/Statistics/Components/StatisticsFilters.tsx
+++ b/resources/js/Pages/Dashboard/Statistics/Components/StatisticsFilters.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import {
     Category,
     Club,
+    Group,
     StatisticsFilters as TStatisticsFilters,
 } from "@/types";
 import { format } from "date-fns";
@@ -27,6 +28,7 @@ interface Props {
     filters: TStatisticsFilters;
     clubs: Club[];
     categories: Category[];
+    groups: Group[];
     onFilterChange: (filters: TStatisticsFilters) => void;
     isLoading: boolean;
 }
@@ -45,6 +47,7 @@ export default function StatisticsFilters({
     filters,
     clubs,
     categories,
+    groups,
     onFilterChange,
     isLoading,
 }: Props) {
@@ -75,6 +78,7 @@ export default function StatisticsFilters({
         onFilterChange({
             ...filters,
             club_id: value === "all" ? null : Number(value),
+            group_id: null,
         });
     };
 
@@ -82,6 +86,14 @@ export default function StatisticsFilters({
         onFilterChange({
             ...filters,
             category_id: value === "all" ? null : Number(value),
+            group_id: null,
+        });
+    };
+
+    const handleGroupChange = (value: string) => {
+        onFilterChange({
+            ...filters,
+            group_id: value === "all" ? null : Number(value),
         });
     };
 
@@ -243,6 +255,32 @@ export default function StatisticsFilters({
                     ))}
                 </SelectContent>
             </Select>
+
+            {/* Group Filter - only shown when groups exist */}
+            {groups.length > 0 && (
+                <Select
+                    dir="rtl"
+                    value={
+                        filters.group_id ? String(filters.group_id) : "all"
+                    }
+                    onValueChange={handleGroupChange}
+                >
+                    <SelectTrigger className="w-[150px]">
+                        <SelectValue placeholder="الفوج" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="all">جميع الأفواج</SelectItem>
+                        {groups.map((group) => (
+                            <SelectItem
+                                key={group.id}
+                                value={String(group.id)}
+                            >
+                                {group.name}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            )}
         </div>
     );
 }

--- a/resources/js/Pages/Dashboard/Statistics/Index.tsx
+++ b/resources/js/Pages/Dashboard/Statistics/Index.tsx
@@ -6,6 +6,7 @@ import {
     StatisticsFilters as TStatisticsFilters,
     Club,
     Category,
+    Group,
     TUser,
 } from "@/types";
 import { useState, useCallback, useMemo } from "react";
@@ -30,6 +31,7 @@ interface Props {
     statistics: Statistics;
     clubs: Club[];
     categories: Category[];
+    groups: Group[];
     filters: TStatisticsFilters;
 }
 
@@ -39,11 +41,13 @@ export default function StatisticsIndex({
     statistics: initialStatistics,
     clubs,
     categories,
+    groups: initialGroups,
     filters: initialFilters,
 }: Props) {
     const [widgets, setWidgets] = useState<Widget[]>(initialLayout);
     const [statistics, setStatistics] = useState<Statistics>(initialStatistics);
     const [filters, setFilters] = useState<TStatisticsFilters>(initialFilters);
+    const [groups, setGroups] = useState<Group[]>(initialGroups);
     const [isLoading, setIsLoading] = useState(false);
 
     // Debounced layout save
@@ -103,9 +107,11 @@ export default function StatisticsIndex({
             if (newFilters.end_date) params.append("end_date", newFilters.end_date);
             if (newFilters.club_id) params.append("club_id", String(newFilters.club_id));
             if (newFilters.category_id) params.append("category_id", String(newFilters.category_id));
+            if (newFilters.group_id) params.append("group_id", String(newFilters.group_id));
 
             const response = await axios.get(`/statistics/data?${params.toString()}`);
-            setStatistics(response.data);
+            setStatistics(response.data.statistics);
+            setGroups(response.data.groups);
         } catch (error) {
             console.error("Failed to fetch statistics:", error);
         } finally {
@@ -172,6 +178,7 @@ export default function StatisticsIndex({
                         filters={filters}
                         clubs={clubs}
                         categories={categories}
+                        groups={groups}
                         onFilterChange={handleFilterChange}
                         isLoading={isLoading}
                     />

--- a/resources/js/Pages/Dashboard/Students/Components/Columns.tsx
+++ b/resources/js/Pages/Dashboard/Students/Components/Columns.tsx
@@ -15,7 +15,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/Components/ui/dropdown-menu";
-import { Link, useForm } from "@inertiajs/react";
+import { Link, router, useForm } from "@inertiajs/react";
 import { ColumnDef } from "@tanstack/react-table";
 import { Banknote, MoreHorizontal, Trash2, UserPen } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -431,8 +431,25 @@ export const columns: ColumnDef<StudentDisplay>[] = [
         header: () => <div className="text-start">المزيد</div>,
         cell: ({ row }) => {
             const student = row.original;
+            const [dialogOpen, setDialogOpen] = useState(false);
+            const [isDeleting, setIsDeleting] = useState(false);
+
+            const handleDelete = () => {
+                setIsDeleting(true);
+                router.delete(`/students/${student.id}`, {
+                    preserveState: true,
+                    preserveScroll: true,
+                    onSuccess: () => {
+                        setDialogOpen(false);
+                    },
+                    onFinish: () => {
+                        setIsDeleting(false);
+                    },
+                });
+            };
+
             return (
-                <Dialog>
+                <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
                     <DropdownMenu dir="rtl">
                         <DropdownMenuTrigger asChild>
                             <Button variant="ghost" className="h-8 w-8 p-0">
@@ -483,16 +500,16 @@ export const columns: ColumnDef<StudentDisplay>[] = [
                                 للطالب
                             </DialogDescription>
                             <DialogFooter>
-                                <Link
-                                    className="px-4 flex items-center gap-2 rounded-md my-0.5 bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                                    href={`/students/${student.id}`}
-                                    method="delete"
-                                    preserveState={false}
-                                    as="button"
+                                <button
+                                    className="px-4 flex items-center gap-2 rounded-md my-0.5 bg-destructive text-destructive-foreground hover:bg-destructive/90 py-2 disabled:opacity-50"
+                                    onClick={handleDelete}
+                                    disabled={isDeleting}
                                 >
                                     <Trash2 />
-                                    <span className="w-full">حذف</span>
-                                </Link>
+                                    <span className="w-full">
+                                        {isDeleting ? "جاري الحذف..." : "حذف"}
+                                    </span>
+                                </button>
                             </DialogFooter>
                         </DialogHeader>
                     </DialogContent>

--- a/resources/js/Pages/Dashboard/Students/Components/DataTable.tsx
+++ b/resources/js/Pages/Dashboard/Students/Components/DataTable.tsx
@@ -7,7 +7,6 @@ import {
     flexRender,
     getCoreRowModel,
     getFilteredRowModel,
-    getPaginationRowModel,
     useReactTable,
 } from "@tanstack/react-table";
 import {
@@ -28,10 +27,11 @@ import {
 } from "@/Components/ui/table";
 import { Button } from "@/Components/ui/button";
 import { Input } from "@/Components/ui/input";
-import { useForm, router } from "@inertiajs/react";
+import { router } from "@inertiajs/react";
 import { FileSpreadsheet, Search } from "lucide-react";
 import { Separator } from "@/Components/ui/separator";
 import { Badge } from "@/Components/ui/badge";
+import { Skeleton } from "@/Components/ui/skeleton";
 
 interface DataTableProps<TData, TValue> {
     columns: ColumnDef<TData, TValue>[];
@@ -43,6 +43,7 @@ interface DataTableProps<TData, TValue> {
         search: string | null;
         sortBy: string | null;
         sortType: string | null;
+        per_page: string | null;
     };
     dataDependencies: {
         categories: {
@@ -91,6 +92,8 @@ const sortedBy = [
     },
 ];
 
+const perPageOptions = [10, 25, 50, 100];
+
 export function DataTable<TData, TValue>({
     columns,
     data,
@@ -102,11 +105,14 @@ export function DataTable<TData, TValue>({
     const [columnVisibility, setColumnVisibility] =
         React.useState<VisibilityState>({});
     const [rowSelection, setRowSelection] = React.useState({});
+    const [searchTerm, setSearchTerm] = React.useState(
+        searchParams.search ?? ""
+    );
     const [selectedSortBy, setSelectedSortBy] = React.useState(
         searchParams.sortBy ?? sortedBy[0].value
     );
     const [sortTypeIsAsc, setSortTypeIsAsc] = React.useState(
-        searchParams.sortType === "asc" ? true : false
+        searchParams.sortType === "asc"
     );
     const [selectedGender, setSelectedGender] = React.useState<string[]>(
         searchParams.gender ?? []
@@ -117,24 +123,18 @@ export function DataTable<TData, TValue>({
     const [selectedCategory, setSelectedCategory] = React.useState<string[]>(
         searchParams.categories ?? []
     );
-    const {
-        setData,
-        get,
-        data: formData,
-        processing,
-    } = useForm({
-        search: searchParams.search,
-        sortBy: selectedSortBy,
-        sortType: sortTypeIsAsc ? "asc" : "desc",
-        gender: selectedGender,
-        clubs: selectedClub,
-        categories: selectedCategory,
-    });
+    const [selectedPerPage, setSelectedPerPage] = React.useState(
+        searchParams.per_page ? parseInt(searchParams.per_page) : 10
+    );
+    const [isLoading, setIsLoading] = React.useState(false);
+
+    const isInitialMount = React.useRef(true);
+    const debounceTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
     const table = useReactTable({
         data,
         columns,
         getCoreRowModel: getCoreRowModel(),
-        getPaginationRowModel: getPaginationRowModel(),
         getSortedRowModel: getSortedRowModel(),
         onColumnFiltersChange: setColumnFilters,
         getFilteredRowModel: getFilteredRowModel(),
@@ -147,41 +147,65 @@ export function DataTable<TData, TValue>({
         },
     });
 
+    const buildRequestData = React.useCallback(() => ({
+        search: searchTerm || undefined,
+        sortBy: selectedSortBy,
+        sortType: sortTypeIsAsc ? "asc" : "desc",
+        gender: selectedGender.length > 0 ? selectedGender : undefined,
+        clubs: selectedClub.length > 0 ? selectedClub : undefined,
+        categories: selectedCategory.length > 0 ? selectedCategory : undefined,
+        per_page: selectedPerPage !== 10 ? selectedPerPage : undefined,
+    }), [searchTerm, selectedSortBy, sortTypeIsAsc, selectedGender, selectedClub, selectedCategory, selectedPerPage]);
+
+    const fireRequest = React.useCallback(() => {
+        setIsLoading(true);
+        router.get(route("students.index"), buildRequestData(), {
+            preserveState: true,
+            preserveScroll: true,
+            onFinish: () => setIsLoading(false),
+        });
+    }, [buildRequestData]);
+
+    // Auto-apply filters (sort, gender, category, club, per_page) with debounce
+    React.useEffect(() => {
+        if (isInitialMount.current) {
+            isInitialMount.current = false;
+            return;
+        }
+        if (debounceTimer.current) {
+            clearTimeout(debounceTimer.current);
+        }
+        debounceTimer.current = setTimeout(() => {
+            fireRequest();
+        }, 300);
+        return () => {
+            if (debounceTimer.current) {
+                clearTimeout(debounceTimer.current);
+            }
+        };
+    }, [selectedSortBy, sortTypeIsAsc, selectedGender, selectedClub, selectedCategory, selectedPerPage]);
+
     const handleSearchTermChange = (
         event: React.ChangeEvent<HTMLInputElement>
     ) => {
-        const searchValue = event.target.value;
-        setData("search", searchValue);
+        setSearchTerm(event.target.value);
     };
     const handleSearchRequest = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        get(route("students.index"), {
-            preserveState: true,
-            preserveScroll: true,
-        });
+        fireRequest();
     };
     const handleSortByChange = (value: string) => {
         setSelectedSortBy(value);
-        setData("sortBy", value);
-        //handleSearchRequest((new Event('submit') as unknown) as React.FormEvent<HTMLFormElement>);
     };
     const handleSortTypeChange = (value: boolean) => {
         setSortTypeIsAsc(value);
-        setData("sortType", value ? "asc" : "desc");
-        //handleSearchRequest(new Event('submit') as unknown as React.FormEvent<HTMLFormElement>);
     };
     const handleGenderChange = (gender: string) => {
-        const updatedSelectedGender = (prevSelected: string[]) =>
-            prevSelected.includes(gender)
-                ? prevSelected.filter((item) => item !== gender)
-                : [...prevSelected, gender];
-
-        setSelectedGender((prevSelected) => {
-            const newSelectedGender = updatedSelectedGender(prevSelected);
-            setData("gender", newSelectedGender);
-            return newSelectedGender;
-        });
-        //handleSearchRequest((new Event('submit') as unknown) as React.FormEvent<HTMLFormElement>);
+        setSelectedGender((prev) =>
+            prev.includes(gender)
+                ? prev.filter((item) => item !== gender)
+                : [...prev, gender]
+        );
     };
     const genderTotals: { [key: string]: number } =
         dataDependencies.genders.reduce(
@@ -192,42 +216,31 @@ export function DataTable<TData, TValue>({
             {}
         );
     const handleCategoryChange = (categoryId: string) => {
-        const updatedSelectedCategory = (prevSelected: string[]) =>
-            prevSelected.includes(categoryId)
-                ? prevSelected.filter((item) => item !== categoryId)
-                : [...prevSelected, categoryId];
-
-        setSelectedCategory((prevSelected) => {
-            const newSelectedCategory = updatedSelectedCategory(prevSelected);
-            setData("categories", newSelectedCategory);
-            return newSelectedCategory;
-        });
-        //handleSearchRequest((new Event('submit') as unknown) as React.FormEvent<HTMLFormElement>);
+        setSelectedCategory((prev) =>
+            prev.includes(categoryId)
+                ? prev.filter((item) => item !== categoryId)
+                : [...prev, categoryId]
+        );
     };
     const handleClubChange = (clubId: string) => {
-        const updatedSelectedClub = (prevSelected: string[]) =>
-            prevSelected.includes(clubId)
-                ? prevSelected.filter((item) => item !== clubId)
-                : [...prevSelected, clubId];
-
-        setSelectedClub((prevSelected) => {
-            const newSelectedClub = updatedSelectedClub(prevSelected);
-            setData("clubs", newSelectedClub);
-            return newSelectedClub;
-        });
-        //handleSearchRequest((new Event('submit') as unknown) as React.FormEvent<HTMLFormElement>);
+        setSelectedClub((prev) =>
+            prev.includes(clubId)
+                ? prev.filter((item) => item !== clubId)
+                : [...prev, clubId]
+        );
+    };
+    const handlePerPageChange = (value: string) => {
+        setSelectedPerPage(parseInt(value));
     };
     const handleExport = () => {
-        // amit the _blank target to open the link in a new tab
-        console.log(formData);
         window.open(
             route("students.export", {
-                search: formData.search,
-                sortBy: formData.sortBy,
-                sortType: formData.sortType,
-                categories: formData.categories,
-                clubs: formData.clubs,
-                gender: formData.gender
+                search: searchTerm || undefined,
+                sortBy: selectedSortBy,
+                sortType: sortTypeIsAsc ? "asc" : "desc",
+                categories: selectedCategory.length > 0 ? selectedCategory : undefined,
+                clubs: selectedClub.length > 0 ? selectedClub : undefined,
+                gender: selectedGender.length > 0 ? selectedGender : undefined,
             }),
             "_new"
         );
@@ -242,11 +255,11 @@ export function DataTable<TData, TValue>({
                 >
                     <Input
                         placeholder="ابحث عن طالب.."
-                        value={formData.search || ""}
+                        value={searchTerm}
                         onChange={handleSearchTermChange}
                         className=""
                     />
-                    <Button disabled={processing} type="submit">
+                    <Button type="submit">
                         <Search />
                     </Button>
                 </form>
@@ -263,7 +276,7 @@ export function DataTable<TData, TValue>({
                                     {
                                         sortedBy.find(
                                             (sort) =>
-                                                sort.value === formData.sortBy
+                                                sort.value === selectedSortBy
                                         )?.label
                                     }
                                 </Button>
@@ -271,7 +284,7 @@ export function DataTable<TData, TValue>({
                             <DropdownMenuContent align="end">
                                 <DropdownMenuRadioGroup
                                     dir="rtl"
-                                    value={formData.sortBy}
+                                    value={selectedSortBy}
                                     onValueChange={handleSortByChange}
                                 >
                                     {sortedBy.map((sort) => (
@@ -290,7 +303,7 @@ export function DataTable<TData, TValue>({
                             variant="outline"
                             onClick={() => handleSortTypeChange(!sortTypeIsAsc)}
                         >
-                            {formData.sortType === "asc"
+                            {sortTypeIsAsc
                                 ? "تصاعديا"
                                 : "تنازليا"}
                         </Button>
@@ -308,7 +321,7 @@ export function DataTable<TData, TValue>({
                                 >
                                     <span>الجنس</span>
                                     <Badge className="px-1.5">
-                                        {formData.gender.length}
+                                        {selectedGender.length}
                                     </Badge>
                                 </Button>
                             </DropdownMenuTrigger>
@@ -316,7 +329,7 @@ export function DataTable<TData, TValue>({
                                 <DropdownMenuCheckboxItem
                                     dir="rtl"
                                     className="capitalize"
-                                    checked={formData.gender.includes("male")}
+                                    checked={selectedGender.includes("male")}
                                     onClick={(e) => {
                                         e.preventDefault();
                                         e.stopPropagation();
@@ -328,7 +341,7 @@ export function DataTable<TData, TValue>({
                                 <DropdownMenuCheckboxItem
                                     dir="rtl"
                                     className="capitalize"
-                                    checked={formData.gender.includes("female")}
+                                    checked={selectedGender.includes("female")}
                                     onClick={(e) => {
                                         e.preventDefault();
                                         e.stopPropagation();
@@ -347,7 +360,7 @@ export function DataTable<TData, TValue>({
                                 >
                                     <span>الفئة</span>
                                     <Badge className="px-1.5">
-                                        {formData.categories.length}
+                                        {selectedCategory.length}
                                     </Badge>
                                 </Button>
                             </DropdownMenuTrigger>
@@ -357,7 +370,7 @@ export function DataTable<TData, TValue>({
                                         dir="rtl"
                                         key={category.id}
                                         className="capitalize"
-                                        checked={formData.categories.includes(
+                                        checked={selectedCategory.includes(
                                             category.id.toString()
                                         )}
                                         onClick={(e) => {
@@ -399,7 +412,7 @@ export function DataTable<TData, TValue>({
                                 >
                                     <span>النادي</span>
                                     <Badge className="px-1.5">
-                                        {formData.clubs.length}
+                                        {selectedClub.length}
                                     </Badge>
                                 </Button>
                             </DropdownMenuTrigger>
@@ -409,7 +422,7 @@ export function DataTable<TData, TValue>({
                                         dir="rtl"
                                         key={club.id}
                                         className="capitalize"
-                                        checked={formData.clubs.includes(
+                                        checked={selectedClub.includes(
                                             club.id.toString()
                                         )}
                                         onClick={(e) => {
@@ -486,7 +499,7 @@ export function DataTable<TData, TValue>({
                             <Button variant="outline">
                                 {
                                     sortedBy.find(
-                                        (sort) => sort.value === formData.sortBy
+                                        (sort) => sort.value === selectedSortBy
                                     )?.label
                                 }
                             </Button>
@@ -494,7 +507,7 @@ export function DataTable<TData, TValue>({
                         <DropdownMenuContent align="end">
                             <DropdownMenuRadioGroup
                                 dir="rtl"
-                                value={formData.sortBy}
+                                value={selectedSortBy}
                                 onValueChange={handleSortByChange}
                             >
                                 {sortedBy.map((sort) => (
@@ -513,7 +526,7 @@ export function DataTable<TData, TValue>({
                         variant="outline"
                         onClick={() => handleSortTypeChange(!sortTypeIsAsc)}
                     >
-                        {formData.sortType === "asc" ? "تصاعديا" : "تنازليا"}
+                        {sortTypeIsAsc ? "تصاعديا" : "تنازليا"}
                     </Button>
                 </div>
                 <Separator
@@ -526,7 +539,7 @@ export function DataTable<TData, TValue>({
                             <Button variant="outline" className="flex gap-1">
                                 <span>الجنس</span>
                                 <Badge className="px-1.5">
-                                    {formData.gender.length}
+                                    {selectedGender.length}
                                 </Badge>
                             </Button>
                         </DropdownMenuTrigger>
@@ -534,7 +547,7 @@ export function DataTable<TData, TValue>({
                             <DropdownMenuCheckboxItem
                                 dir="rtl"
                                 className="capitalize"
-                                checked={formData.gender.includes("male")}
+                                checked={selectedGender.includes("male")}
                                 onClick={(e) => {
                                     e.preventDefault();
                                     e.stopPropagation();
@@ -546,7 +559,7 @@ export function DataTable<TData, TValue>({
                             <DropdownMenuCheckboxItem
                                 dir="rtl"
                                 className="capitalize"
-                                checked={formData.gender.includes("female")}
+                                checked={selectedGender.includes("female")}
                                 onClick={(e) => {
                                     e.preventDefault();
                                     e.stopPropagation();
@@ -562,7 +575,7 @@ export function DataTable<TData, TValue>({
                             <Button variant="outline" className="flex gap-1">
                                 <span>الفئة</span>
                                 <Badge className="px-1.5">
-                                    {formData.categories.length}
+                                    {selectedCategory.length}
                                 </Badge>
                             </Button>
                         </DropdownMenuTrigger>
@@ -572,7 +585,7 @@ export function DataTable<TData, TValue>({
                                     dir="rtl"
                                     key={category.id}
                                     className="capitalize"
-                                    checked={formData.categories.includes(
+                                    checked={selectedCategory.includes(
                                         category.id.toString()
                                     )}
                                     onClick={(e) => {
@@ -611,7 +624,7 @@ export function DataTable<TData, TValue>({
                             <Button variant="outline" className="flex gap-1">
                                 <span>النادي</span>
                                 <Badge className="px-1.5">
-                                    {formData.clubs.length}
+                                    {selectedClub.length}
                                 </Badge>
                             </Button>
                         </DropdownMenuTrigger>
@@ -621,7 +634,7 @@ export function DataTable<TData, TValue>({
                                     dir="rtl"
                                     key={club.id}
                                     className="capitalize"
-                                    checked={formData.clubs.includes(
+                                    checked={selectedClub.includes(
                                         club.id.toString()
                                     )}
                                     onClick={(e) => {
@@ -675,7 +688,17 @@ export function DataTable<TData, TValue>({
                         ))}
                     </TableHeader>
                     <TableBody>
-                        {table.getRowModel().rows?.length ? (
+                        {isLoading ? (
+                            Array.from({ length: selectedPerPage > 10 ? 10 : selectedPerPage }).map((_, i) => (
+                                <TableRow key={`skeleton-${i}`}>
+                                    {columns.map((_, colIdx) => (
+                                        <TableCell key={colIdx} className="p-3">
+                                            <Skeleton className="h-5 w-full" />
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+                            ))
+                        ) : table.getRowModel().rows?.length ? (
                             table.getRowModel().rows.map((row) => (
                                 <TableRow
                                     key={row.id}
@@ -712,3 +735,5 @@ export function DataTable<TData, TValue>({
         </div>
     );
 }
+
+export { perPageOptions };

--- a/resources/js/Pages/Dashboard/Students/Index.tsx
+++ b/resources/js/Pages/Dashboard/Students/Index.tsx
@@ -1,10 +1,17 @@
 import DashboardLayout from "@/Layouts/DashboardLayout";
 import { PageProps } from "@/types";
-import { Head, Link } from "@inertiajs/react";
+import { Head, Link, router } from "@inertiajs/react";
 import { StudentDisplay, columns } from "./Components/Columns";
-import { DataTable } from "./Components/DataTable";
+import { DataTable, perPageOptions } from "./Components/DataTable";
 import { Button } from "@/Components/ui/button";
 import { Plus } from "lucide-react";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuTrigger,
+} from "@/Components/ui/dropdown-menu";
 
 interface DashboardProps extends PageProps {
     students: { data: StudentDisplay[]; links: any[] };
@@ -24,8 +31,6 @@ export default function Dashboard({
     students,
     dataDependencies,
 }: DashboardProps) {
-    //onload check &search= query param
-    // Extract search query parameter
     const urlParams = new URLSearchParams(location.search);
 
     const searchQuery = urlParams.get("search");
@@ -42,6 +47,9 @@ export default function Dashboard({
         return result;
     };
 
+    const perPageQuery = urlParams.get("per_page");
+    const currentPerPage = perPageQuery ? parseInt(perPageQuery) : 10;
+
     const searchParams = {
         categories: getArrayFromParams("categories"),
         clubs: getArrayFromParams("clubs"),
@@ -49,9 +57,25 @@ export default function Dashboard({
         search: searchQuery,
         sortBy: sortByQuery,
         sortType: sortTypeQuery,
+        per_page: perPageQuery,
     };
 
-    // Filter students based on search query
+    const handlePerPageChange = (value: string) => {
+        const params = new URLSearchParams(location.search);
+        if (value === "10") {
+            params.delete("per_page");
+        } else {
+            params.set("per_page", value);
+        }
+        // Reset to page 1 when changing per_page
+        params.delete("page");
+        router.get(
+            `${route("students.index")}?${params.toString()}`,
+            {},
+            { preserveState: true, preserveScroll: true }
+        );
+    };
+
     const translatedLinks = students.links.map((link, index) => {
         if (index === 0) {
             link.label = "&laquo;السابق";
@@ -74,45 +98,74 @@ export default function Dashboard({
                     </Link>
                 </div>
                 <DataTable
+                    key={location.search}
                     columns={columns}
                     data={students.data}
                     searchParams={searchParams}
                     dataDependencies={dataDependencies}
                 />
-                <div className="mt-4 mb-1 flex">
-                    {translatedLinks.map((link) =>
-                        link.url ? (
-                            <Link
-                                preserveState
-                                key={link.label}
-                                href={link.url}
-                                dangerouslySetInnerHTML={{
-                                    __html: link.label,
-                                }}
-                                className={`p-1.5 md:px-2.5 mx-1 rounded-lg select-none ${
-                                    link.active
-                                        ? "text-primary-foreground text-base font-bold bg-primary"
-                                        : "text-neutral-600 hover:text-neutral-950 hover:ring-2 ring-primary"
-                                } ${
-                                    !isNaN(link.label) || link.label === "..."
-                                        ? "lg:inline-block hidden"
-                                        : ""
-                                }`}
-                            />
-                        ) : (
-                            <span
-                                key={link.label}
-                                dangerouslySetInnerHTML={{
-                                    __html: link.label,
-                                }}
-                                className={`p-1.5 mx-1 rounded-lg select-none text-neutral-400 ${
-                                    !isNaN(link.label) || link.label === "..."
-                                        ? "lg:inline-block hidden"
-                                        : ""
-                                }`}
-                            />
-                        )
-                    )}
+                <div className="mt-4 mb-1 flex items-center gap-4">
+                    <div className="flex items-center gap-1.5">
+                        <span className="text-sm text-muted-foreground">عرض</span>
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="outline" size="sm" className="h-8 px-2.5">
+                                    {currentPerPage}
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="center">
+                                <DropdownMenuRadioGroup
+                                    dir="rtl"
+                                    value={String(currentPerPage)}
+                                    onValueChange={handlePerPageChange}
+                                >
+                                    {perPageOptions.map((option) => (
+                                        <DropdownMenuRadioItem
+                                            key={option}
+                                            value={String(option)}
+                                        >
+                                            {option}
+                                        </DropdownMenuRadioItem>
+                                    ))}
+                                </DropdownMenuRadioGroup>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </div>
+                    <div className="flex">
+                        {translatedLinks.map((link) =>
+                            link.url ? (
+                                <Link
+                                    preserveState
+                                    key={link.label}
+                                    href={link.url}
+                                    dangerouslySetInnerHTML={{
+                                        __html: link.label,
+                                    }}
+                                    className={`p-1.5 md:px-2.5 mx-1 rounded-lg select-none ${
+                                        link.active
+                                            ? "text-primary-foreground text-base font-bold bg-primary"
+                                            : "text-neutral-600 hover:text-neutral-950 hover:ring-2 ring-primary"
+                                    } ${
+                                        !isNaN(link.label) || link.label === "..."
+                                            ? "lg:inline-block hidden"
+                                            : ""
+                                    }`}
+                                />
+                            ) : (
+                                <span
+                                    key={link.label}
+                                    dangerouslySetInnerHTML={{
+                                        __html: link.label,
+                                    }}
+                                    className={`p-1.5 mx-1 rounded-lg select-none text-neutral-400 ${
+                                        !isNaN(link.label) || link.label === "..."
+                                            ? "lg:inline-block hidden"
+                                            : ""
+                                    }`}
+                                />
+                            )
+                        )}
+                    </div>
                 </div>
             </div>
         </DashboardLayout>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -215,6 +215,12 @@ export interface StatisticsFilters {
     end_date: string | null;
     club_id: number | null;
     category_id: number | null;
+    group_id: number | null;
+}
+
+export interface Group {
+    id: number;
+    name: string;
 }
 
 export interface Club {


### PR DESCRIPTION
in the route `/students` 
- The filter goes when a student is deleted, the filter should stay
- The limit of showing 10 students per page should be changeable in the UI to show more, as using 10 as the default value
- The filters only apply when u click the submit button to search it should be done when a filter is selected/changed
in the route `/statistics`  
- There is no option to see a groupe stats only clubs and categories if the clubs & categories have groups a new select field should appear to select the group A,B... or all