### PR TITLE
feat: Integrate Umami analytics for privacy-friendly usage tracking and session replays

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,38 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+#---------------------------------------------------------------
+# Umami Analytics (optional)
+#---------------------------------------------------------------
+# Stream privacy-friendly, cookieless usage data to your Umami
+# instance. Set both UMAMI_WEBSITE_ID and UMAMI_SCRIPT_URL to
+# enable; leave them empty to disable (no script is loaded).
+# View your stats from the Umami dashboard itself.
+#
+# Cloud:       UMAMI_SCRIPT_URL=https://cloud.umami.is/script.js
+# Self-hosted: UMAMI_SCRIPT_URL=https://your-umami.example.com/script.js
+#---------------------------------------------------------------
+UMAMI_WEBSITE_ID=
+UMAMI_SCRIPT_URL=
+
+# Optional tracker tweaks — see https://docs.umami.is/docs/tracker-configuration
+# UMAMI_HOST_URL=                 # send events to a different origin
+# UMAMI_DOMAINS=example.com,foo.com   # restrict tracking to these domains
+# UMAMI_TAG=                      # label events for filtering / A-B testing
+# UMAMI_PERFORMANCE=true          # collect Core Web Vitals (Umami v3.1+)
+
+#---------------------------------------------------------------
+# Umami Replays (optional, requires Umami v3.x w/ Replays enabled)
+# https://docs.umami.is/docs/replays
+#---------------------------------------------------------------
+# Set UMAMI_REPLAY=true and provide UMAMI_REPLAY_RECORDER_URL to load
+# the session recorder. Defaults match Umami's recommended values.
+# Remember to enable Replays in the Umami dashboard for the website too.
+#---------------------------------------------------------------
+# UMAMI_REPLAY=true
+# UMAMI_REPLAY_RECORDER_URL=https://cloud.umami.is/recorder.js
+# UMAMI_REPLAY_SAMPLE_RATE=0.15              # 0.0–1.0 (15% of sessions)
+# UMAMI_REPLAY_MASK_LEVEL=moderate           # "moderate" or "strict"
+# UMAMI_REPLAY_MAX_DURATION=300000           # milliseconds (5 minutes)
+# UMAMI_REPLAY_BLOCK_SELECTOR=               # CSS selector to skip recording

--- a/README.md
+++ b/README.md
@@ -15,6 +15,32 @@ ADMIN_EMAIL=your-email
 ADMIN_PASSWORD=your-password
 ```
 
+## Analytics (optional)
+
+Athar can stream privacy-friendly, cookieless usage stats to a [Umami](https://umami.is/) instance (Cloud or self-hosted, v3.x). Set two env vars and you're done:
+
+```
+UMAMI_WEBSITE_ID=your-website-id
+UMAMI_SCRIPT_URL=https://cloud.umami.is/script.js   # or https://your-umami.example.com/script.js
+```
+
+When both are set, the tracker is injected into the page and SPA navigations are captured automatically. Logged-in users are linked to their Umami session via `umami.identify()`, so the *Sessions* view in your Umami dashboard shows the user's name, email, and role. View all stats from the Umami dashboard itself.
+
+Leave `UMAMI_WEBSITE_ID` empty to disable — no script is loaded and no analytics calls are made.
+
+Optional tracker knobs (see `.env.example`): `UMAMI_HOST_URL`, `UMAMI_DOMAINS`, `UMAMI_TAG`, `UMAMI_PERFORMANCE` (Core Web Vitals, v3.1+).
+
+### Replays (optional)
+
+If your Umami instance has [Replays](https://docs.umami.is/docs/replays) enabled, Athar can also load the recorder. Set:
+
+```
+UMAMI_REPLAY=true
+UMAMI_REPLAY_RECORDER_URL=https://cloud.umami.is/recorder.js   # or https://your-umami.example.com/recorder.js
+```
+
+Defaults match Umami's recommended values: 15% sample rate, "moderate" mask level, 5-minute max duration. Override via `UMAMI_REPLAY_SAMPLE_RATE`, `UMAMI_REPLAY_MASK_LEVEL`, `UMAMI_REPLAY_MAX_DURATION`, `UMAMI_REPLAY_BLOCK_SELECTOR` if needed. Replays must also be enabled per-website in the Umami dashboard before recordings are stored.
+
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -17,7 +17,7 @@ class HandleInertiaRequests extends Middleware
     /**
      * Determine the current asset version.
      */
-    public function version(Request $request): string|null
+    public function version(Request $request): ?string
     {
         return parent::version($request);
     }

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,22 @@ return [
         ],
     ],
 
+    'umami' => [
+        'website_id' => env('UMAMI_WEBSITE_ID'),
+        'script_url' => env('UMAMI_SCRIPT_URL'),
+        'host_url' => env('UMAMI_HOST_URL'),
+        'domains' => env('UMAMI_DOMAINS'),
+        'tag' => env('UMAMI_TAG'),
+        'performance' => env('UMAMI_PERFORMANCE', false),
+
+        'replay' => [
+            'enabled' => env('UMAMI_REPLAY', false),
+            'recorder_url' => env('UMAMI_REPLAY_RECORDER_URL'),
+            'sample_rate' => env('UMAMI_REPLAY_SAMPLE_RATE', '0.15'),
+            'mask_level' => env('UMAMI_REPLAY_MASK_LEVEL', 'moderate'),
+            'max_duration' => env('UMAMI_REPLAY_MAX_DURATION', '300000'),
+            'block_selector' => env('UMAMI_REPLAY_BLOCK_SELECTOR'),
+        ],
+    ],
+
 ];

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -2,10 +2,57 @@ import './bootstrap';
 import '../css/app.css';
 
 import { createRoot } from 'react-dom/client';
-import { createInertiaApp } from '@inertiajs/react';
+import { createInertiaApp, router } from '@inertiajs/react';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+
+type UmamiAPI = {
+    identify: (id: string | number, data?: Record<string, unknown>) => void;
+};
+
+type IdentifyProps = {
+    auth?: {
+        user?: {
+            id: number | string;
+            name?: string;
+            last_name?: string;
+            email?: string;
+            role?: string;
+        } | null;
+    };
+};
+
+let lastIdentifiedFingerprint: string | null = null;
+
+function identifyUmami(props: IdentifyProps, attempt = 0): void {
+    const user = props.auth?.user;
+    if (!user?.id) {
+        return;
+    }
+    const fingerprint = JSON.stringify([
+        user.id,
+        user.name,
+        user.last_name,
+        user.email,
+        user.role,
+    ]);
+    if (fingerprint === lastIdentifiedFingerprint) {
+        return;
+    }
+    const umami = (window as unknown as { umami?: UmamiAPI }).umami;
+    if (umami) {
+        umami.identify(String(user.id), {
+            name: user.name,
+            last_name: user.last_name,
+            email: user.email,
+            role: user.role,
+        });
+        lastIdentifiedFingerprint = fingerprint;
+    } else if (attempt < 30) {
+        window.setTimeout(() => identifyUmami(props, attempt + 1), 100);
+    }
+}
 
 createInertiaApp({
     title: (title) => `${title} - ${appName}`,
@@ -14,8 +61,14 @@ createInertiaApp({
         const root = createRoot(el);
 
         root.render(<App {...props} />);
+
+        identifyUmami(props.initialPage.props as IdentifyProps);
     },
     progress: {
         color: '#4B5563',
     },
+});
+
+router.on('navigate', (event) => {
+    identifyUmami(event.detail.page.props as IdentifyProps);
 });

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -24,6 +24,30 @@
     @viteReactRefresh
     @vite(['resources/js/app.tsx', "resources/js/Pages/{$page['component']}.tsx"])
     @inertiaHead
+
+    @if (filled(config('services.umami.website_id')) && filled(config('services.umami.script_url')))
+        <script
+            defer
+            src="{{ config('services.umami.script_url') }}"
+            data-website-id="{{ config('services.umami.website_id') }}"
+            @if (filled(config('services.umami.host_url'))) data-host-url="{{ config('services.umami.host_url') }}" @endif
+            @if (filled(config('services.umami.domains'))) data-domains="{{ config('services.umami.domains') }}" @endif
+            @if (filled(config('services.umami.tag'))) data-tag="{{ config('services.umami.tag') }}" @endif
+            @if (config('services.umami.performance')) data-performance="true" @endif
+        ></script>
+
+        @if (config('services.umami.replay.enabled') && filled(config('services.umami.replay.recorder_url')))
+            <script
+                defer
+                src="{{ config('services.umami.replay.recorder_url') }}"
+                data-website-id="{{ config('services.umami.website_id') }}"
+                data-sample-rate="{{ config('services.umami.replay.sample_rate') }}"
+                data-mask-level="{{ config('services.umami.replay.mask_level') }}"
+                data-max-duration="{{ config('services.umami.replay.max_duration') }}"
+                @if (filled(config('services.umami.replay.block_selector'))) data-block-selector="{{ config('services.umami.replay.block_selector') }}" @endif
+            ></script>
+        @endif
+    @endif
 </head>
 
 <body class="font-sans antialiased overflow-hidden">


### PR DESCRIPTION
This pull request adds optional integration with Umami Analytics and Replays, allowing the app to stream privacy-friendly usage stats and session replays to a configured Umami instance. The integration is fully configurable via environment variables and is documented for easy setup. Additionally, the code ensures that logged-in users are identified in Umami for richer analytics.

**Umami Analytics and Replays Integration:**

* Added new environment variables in `.env.example` for configuring Umami Analytics and Replays, including tracker tweaks and replay options.
* Updated `config/services.php` to include a new `umami` configuration section, mapping all Umami-related environment variables for analytics and replays.
* Injected the Umami analytics script (and optionally the Replays recorder) into the main Blade template (`resources/views/app.blade.php`) when the relevant environment variables are set. This enables analytics and session replay tracking when configured.

**Frontend User Identification:**

* Added logic in `resources/js/app.tsx` to call `umami.identify()` with the logged-in user's details on page load and SPA navigations, ensuring user sessions in Umami are linked to user identity (name, email, role).

**Documentation:**

* Updated `README.md` with clear instructions for enabling and configuring Umami Analytics and Replays, including environment variable descriptions and links to Umami documentation.

**Other:**

* Minor code style update in `HandleInertiaRequests` (nullable return type syntax).